### PR TITLE
Configparser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project("webserv")
 
 set(CMAKE_CXX_STANDARD 98)
 
+add_compile_options(-g3 -fsanitize=address)
+add_link_options(-g3 -fsanitize=address)
+
 set(SOURCE_FILES
         src/Server.cpp
         src/main.cpp

--- a/config/default.conf
+++ b/config/default.conf
@@ -8,41 +8,7 @@ server {
 
 	autoindex : on;
 	index : index.html index2.html;
-	client_body_limit : 4096;
-	
-	error_page {
-		404 : ./www/html/error/error.html;
-		405 : ./www/html/error/error.html;
-		505 : ./www/html/error/error2.html;
-		500 : ./www/html/error/error2.html;
-	}
-	location/board {
-			allow_methods : GET;
-			root : ./www/html;
-	}
-	location/board/content {
-			allow_methods : GET POST DELETE;
-			root : ./www/html/contents;
-			index : board.html;
-			cgi_info : .php php-cgi;
-	}
-	location/cgi {
-		allow_methods : GET POST;
-		cgi_info : php php-fpm;
-	}
-}
-
-server {
-	server_name : webserv1;
-	listen : 0.0.0.0:42424;
-
-	root : ./www/html;
-
-	allow_methods : GET POST DELETE;
-
-	autoindex : on;
-	index : index.html index2.html;
-	client_body_limit : 4096;
+	client_max_body_size : 10000;
 	
 	error_page {
 		404 : ./www/html/error/error.html;

--- a/config/default.conf
+++ b/config/default.conf
@@ -16,17 +16,17 @@ server {
 		505 : ./www/html/error/error2.html;
 		500 : ./www/html/error/error2.html;
 	}
-	location/board {
+	location /board {
 			allow_methods : GET;
 			root : ./www/html;
 	}
-	location/board/content {
+	location /board/content {
 			allow_methods : GET POST DELETE;
 			root : ./www/html/contents;
 			index : board.html;
 			cgi_info : .php php-cgi;
 	}
-	location/cgi {
+	location /cgi {
 		allow_methods : GET POST;
 		cgi_info : php php-fpm;
 	}

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -36,8 +36,10 @@ private:
     void getServerAttr(Server& server, unsigned int server_index);
     void getLocationAttr(Server& server, unsigned int server_index);
     void displayServer(Server& server);
+    void getErrorPage(std::map<StatusCode, std::string>& _errorPage, unsigned int server_index);
 public:
     std::vector<std::string> GetNodeElem(size_t server_index, std::string categoly ,std::string key);
+    ParserNode* getNode(size_t server_index, std::string categoly);
     static bool vaildCheck(std::string FileRoot);
     std::vector<Server> parsing(std::string FileRoot);
 };

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -11,14 +11,14 @@ struct ParserNode
 {
     ParserNode *next;
     ParserNode *prev;
-    std::string categoly;
+    std::string category;
     std::map<std::string, std::vector<std::string> > elem;
 };
 
 class CommonParser
 {
 protected:
-    std::vector<ParserNode> nodevector;
+    std::vector<ParserNode> _nodeVector;
 public:
     bool IsNodeElemEmpty(ParserNode node);
     ParserNode* GetNextNode(ParserNode node);
@@ -29,17 +29,17 @@ public:
 class ConfigParser : public CommonParser
 {
 private:
-    void getElem(ParserNode* temp, std::string line);
-    ParserNode* EnterNode(ParserNode* temp, std::string line);
+    void getElem(ParserNode* temp, const std::string& line);
+    ParserNode* EnterNode(ParserNode* temp, const std::string& line);
     void parsingOneNode(std::istream& is);
-    void getAllowMethods(std::vector<MethodType>& _allowMethods, std::string categoly, unsigned int server_index);
+    void getAllowMethods(std::vector<MethodType>& _allowMethods, const std::string& category, unsigned int server_index);
     void getServerAttr(Server& server, unsigned int server_index);
     void getLocationAttr(Server& server, unsigned int server_index);
     void displayServer(Server& server);
     void getErrorPage(std::map<StatusCode, std::string>& _errorPage, unsigned int server_index);
 public:
-    std::vector<std::string> GetNodeElem(size_t server_index, std::string categoly ,std::string key);
-    ParserNode* getNode(size_t server_index, std::string categoly);
-    static bool vaildCheck(std::string FileRoot);
-    std::vector<Server> parsing(std::string FileRoot);
+    std::vector<std::string> GetNodeElem(size_t server_index, const std::string& category , const std::string& key);
+    ParserNode* getNode(size_t server_index, const std::string& category);
+    static bool vaildCheck(const std::string& FileRoot);
+    std::vector<Server> parsing(const std::string& FileRoot);
 };

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -32,7 +32,10 @@ private:
     void getElem(ParserNode* temp, std::string line);
     ParserNode* EnterNode(ParserNode* temp, std::string line);
     void parsingOneNode(std::istream& is);
+    void getAllowMethods(std::vector<MethodType>& _allowMethods, std::string categoly, unsigned int server_index);
     void getServerAttr(Server& server, unsigned int server_index);
+    void getLocationAttr(Server& server, unsigned int server_index);
+    void displayServer(Server& server);
 public:
     std::vector<std::string> GetNodeElem(size_t server_index, std::string categoly ,std::string key);
     static bool vaildCheck(std::string FileRoot);

--- a/include/RequestParser.hpp
+++ b/include/RequestParser.hpp
@@ -1,0 +1,16 @@
+#include "WebservDefines.hpp"
+#include <map>
+#include <string>
+
+class RequestParser
+{
+private:
+    std::map<FileDescriptor, std::string> _MessegeList;
+public:
+    RequestParser();
+    ~RequestParser();
+    bool RequestParsing();
+    void addFD();
+    void eraseFD();
+    bool messegeCheck();
+};

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -12,6 +12,8 @@
 #include <vector>
 #include <string>
 
+typedef int StatusCode;
+
 class Server
 {
 // attributes
@@ -20,6 +22,7 @@ public:
     struct sockaddr_in _socketAddr;
     std::string _index;
     std::string _root;
+    std::map<StatusCode, std::string> _errorPage;
     std::vector<MethodType> _allowMethods;
     std::vector<Location> _locations;
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -2,6 +2,7 @@
 #define SERVER_HPP
 
 #include "WebservDefines.hpp"
+#include <map>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/include/WebservDefines.hpp
+++ b/include/WebservDefines.hpp
@@ -33,12 +33,12 @@ typedef int FileDescriptor;
 // FIXME
 struct Location
 {
-    std::string _location;
-    std::string _index;              // ex. index.html
-    std::string _root;               // ex ./myDir/...
-    std::vector<MethodType> _allowMethods;       // ex. GET POST DELETE ...
-    int  client_max_body_size;  // (--> max size of client body request)   --> defaults to 8000 bytes
-    std::vector<std::string> _cgiInfo;			// ex. name: cgi_tester, arg: hello_world
+    std::string location;
+    std::string index;              // ex. index.html
+    std::string root;               // ex ./myDir/...
+    std::vector<MethodType> allowMethods;       // ex. GET POST DELETE ...
+    int  ClientMaxBodySize;  // (--> max size of client body request)   --> defaults to 8000 bytes
+    std::vector<std::string> cgiInfo;			// ex. name: cgi_tester, arg: hello_world
 };
 
 void printLog(const std::string& log, const std::string& color);

--- a/include/WebservDefines.hpp
+++ b/include/WebservDefines.hpp
@@ -37,7 +37,7 @@ struct Location
     std::string _index;              // ex. index.html
     std::string _root;               // ex ./myDir/...
     std::vector<MethodType> _allowMethods;       // ex. GET POST DELETE ...
-    int  _clientRequestBodyMaxSize;  // (--> max size of client body request)   --> defaults to 8000 bytes
+    int  client_max_body_size;  // (--> max size of client body request)   --> defaults to 8000 bytes
     std::vector<std::string> _cgiInfo;			// ex. name: cgi_tester, arg: hello_world
 };
 

--- a/include/WebservDefines.hpp
+++ b/include/WebservDefines.hpp
@@ -2,6 +2,7 @@
  #define WEBSERV_DEFINES_HPP
 
 #include <string>
+#include <vector>
 
 #define BUFFER_SIZE 8192
 #define LISTEN_QUEUE_SIZE 1024
@@ -37,7 +38,7 @@ struct Location
     std::string _root;               // ex ./myDir/...
     std::vector<MethodType> _allowMethods;       // ex. GET POST DELETE ...
     int  _clientRequestBodyMaxSize;  // (--> max size of client body request)   --> defaults to 8000 bytes
-    //t_cgiInfo		_cgiInfo;			// ex. name: cgi_tester, arg: hello_world
+    std::vector<std::string> _cgiInfo;			// ex. name: cgi_tester, arg: hello_world
 };
 
 void printLog(const std::string& log, const std::string& color);

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -132,7 +132,7 @@ ParserNode* ConfigParser::EnterNode(ParserNode* temp, std::string line)
     temp = temp->next;
     for (std::string::iterator it = line.begin(); it != line.end(); ++it)
     {
-        if (isblank(*it) || *it == '{')
+        if ((isblank(*it) && *(it + 1) != '/') || *it == '{')
             continue;
         temp->categoly += *it;
     }
@@ -224,11 +224,11 @@ void ConfigParser::getLocationAttr(Server& server, unsigned int server_index)
 
     for (ParserNode* temp = nodevector[server_index].next; temp != NULL; temp = temp->next)
     {
-        found = temp->categoly.find("location");
+        found = temp->categoly.find("location ");
         if (found != std::string::npos)
         {
             temp_cate = temp->categoly;
-            temp_cate.erase(temp_cate.begin(), temp_cate.begin() + 8);
+            temp_cate.erase(temp_cate.begin(), temp_cate.begin() + 9);
             location._location = temp_cate;
             location._index = *(GetNodeElem(server_index, temp->categoly, "index").begin());
             location._root = *(GetNodeElem(server_index, temp->categoly, "root").begin());
@@ -261,7 +261,7 @@ void ConfigParser::displayServer(Server& server)
         std::cout << "_index : " << server._locations[i]._index << std::endl;
         std::cout << "_root : " << server._locations[i]._root << std::endl;
         std::cout << "maxsize : " << server._locations[i].client_max_body_size << std::endl;
-        std::cout << "location : ";
+        std::cout << "location allow methods: ";
         for (unsigned int k = 0; k < server._locations[i]._allowMethods.size(); ++k)
             std::cout << server._locations[i]._allowMethods[k] << " ";
         std::cout << std::endl;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,319 +1,366 @@
 #include "Parser.hpp"
 #include "Server.hpp"
 #include <cctype>
+
 //CommonParser
 bool CommonParser::IsNodeElemEmpty(ParserNode node)
 {
-    if (node.elem.size() == 0)
-        return true;
-    return false;
+  if (node.elem.empty())
+  {
+    return (true);
+  }
+  return (false);
 }
 
-ParserNode* CommonParser::GetNextNode(ParserNode node)
+ParserNode *CommonParser::GetNextNode(ParserNode node)
 {
-    return (node.next);
+  return (node.next);
 }
 
-ParserNode* ConfigParser::getNode(size_t server_index, std::string categoly)
+ParserNode *ConfigParser::getNode(size_t server_index, const std::string& category)
 {
-    ParserNode *temp = NULL;
+  ParserNode *temp = NULL;
 
-    temp = nodevector[server_index].next;
-    while (temp->categoly != categoly)
-            temp = temp->next;
-    return temp;
+  temp = _nodeVector[server_index].next;
+  while (temp && temp->category != category)
+  {
+    temp = temp->next;
+  }
+  return (temp);
 }
 
-std::vector<std::string> ConfigParser::GetNodeElem(size_t server_index, std::string categoly, std::string key)
+std::vector<std::string> ConfigParser::GetNodeElem(size_t server_index,
+                                                   const std::string& category,
+                                                   const std::string& key)
 {
-    ParserNode *temp = NULL;
-    std::vector<std::string> empty;
-    std::map<std::string, std::vector<std::string> >::iterator it;
+  ParserNode *temp = NULL;
+  std::vector<std::string> empty;
+  std::map<std::string, std::vector<std::string> >::iterator it;
 
-    temp = nodevector[server_index].next;
-    while (temp->categoly != categoly)
-            temp = temp->next;
+  temp = _nodeVector[server_index].next;
+  while (temp && temp->category != category)
+  {
+    temp = temp->next;
+  }
+  if (temp)
     it = temp->elem.find(key);
-    if (it == temp->elem.end())
-    {
-        empty.resize(1);
-        return empty;
-    }
-    return it->second;
+  if (temp == NULL || it == temp->elem.end())
+  {
+    empty.resize(1);
+    return (empty);
+  }
+  return (it->second);
 }
 
 void CommonParser::displayAll()
 {
-    for (unsigned int i = 0; i < nodevector.size(); ++i)
+  for (unsigned int i = 0; i < _nodeVector.size(); ++i)
+  {
+    ParserNode *temp = &_nodeVector[i];
+    while (temp)
     {
-        ParserNode *temp = &nodevector[i];
-        while (temp)
-        {
-            std::cout << temp->categoly << std::endl;
-            for (std::map<std::string, std::vector<std::string> >::iterator it = temp->elem.begin(); \
+      std::cout << temp->category << std::endl;
+      for (std::map<std::string, std::vector<std::string> >::iterator it = temp->elem.begin(); \
                 it != temp->elem.end(); ++it)
-            {
-                std::cout << "  "<<it->first << " : ";
-                for (unsigned long i = 0; i < it->second.size(); ++i)
-                {
-                    std::cout << it->second[i] << " ";
-                }
-                std::cout << std::endl;
-            }
-            temp = temp->next;
+      {
+        std::cout << "  " << it->first << " : ";
+        for (unsigned long secondIdx = 0; secondIdx < it->second.size(); ++secondIdx)
+        {
+          std::cout << it->second[secondIdx] << " ";
         }
+        std::cout << std::endl;
+      }
+      temp = temp->next;
     }
+  }
 }
 
 //ConfigParser
-bool ConfigParser::vaildCheck(std::string FileRoot)
+bool ConfigParser::vaildCheck(const std::string& FileRoot)
 {
-    std::stack<char> checkStack;
-    std::filebuf fb;
-    char getChar;
+  std::stack<char> checkStack;
+  std::filebuf fb;
+  char getChar;
 
-    if (fb.open(FileRoot, std::ios::in) == NULL)
-        return false;
-    std::istream is(&fb);
-    while (is)
+  if (fb.open(FileRoot, std::ios::in) == NULL)
+  {
+    return (false);
+  }
+  std::istream is(&fb);
+  while (is)
+  {
+    getChar = static_cast<char>(is.get());
+    if (getChar == '{')
     {
-        getChar = static_cast<char>(is.get());
-        if (getChar == '{')
-            checkStack.push(getChar);
-        else if (getChar == '}')
-        {
-            if (checkStack.top() == '{')
-                checkStack.pop();
-            else
-                checkStack.push(getChar);
-        }
+      checkStack.push(getChar);
     }
-    fb.close();
-    if (checkStack.empty())
-        return (true);
-    return false;
+    else if (getChar == '}')
+    {
+      if (checkStack.top() == '{')
+      {
+        checkStack.pop();
+      }
+      else
+      {
+        checkStack.push(getChar);
+      }
+    }
+  }
+  fb.close();
+  if (checkStack.empty())
+  {
+    return (true);
+  }
+  return (false);
 }
+
 // private
-void ConfigParser::getElem(ParserNode* temp, std::string line)
+void ConfigParser::getElem(ParserNode *temp, const std::string& line)
 {
-    std::string key;
-    std::string buffer;
-    std::vector<std::string> value;
+  std::string key;
+  std::string buffer;
+  std::vector<std::string> value;
 
-    for (std::string::iterator it = line.begin(); it != line.end(); ++it)
+  for (std::string::const_iterator it = line.begin(); it != line.end(); ++it)
+  {
+    if (isblank(*it) || *it == ';')
     {
-        if (isblank(*it) || *it == ';')
-        {
-            if (!key.empty() && !buffer.empty())
-            {
-                value.push_back(buffer);
-                buffer.clear();
-            }
-            continue;
-        }
-        if (*it == ':' && key.size() == 0)
-        {
-            key = buffer;
-            buffer.clear();
-        }
-        else
-            buffer += *it;
+      if (!key.empty() && !buffer.empty())
+      {
+        value.push_back(buffer);
+        buffer.clear();
+      }
+      continue;
     }
-    temp->elem[key] = value;
+    if (*it == ':' && key.empty())
+    {
+      key = buffer;
+      buffer.clear();
+    }
+    else
+    {
+      buffer += *it;
+    }
+  }
+  temp->elem[key] = value;
 }
 
-ParserNode* ConfigParser::EnterNode(ParserNode* temp, std::string line)
+ParserNode *ConfigParser::EnterNode(ParserNode *temp, const std::string& line)
 {
-    while (temp->next)
-        temp = temp->next;
-    temp->next = new ParserNode;
-    temp->next->prev = temp;
-    temp->next->next = NULL;
+  while (temp->next)
+  {
     temp = temp->next;
-    for (std::string::iterator it = line.begin(); it != line.end(); ++it)
+  }
+  temp->next = new ParserNode;
+  temp->next->prev = temp;
+  temp->next->next = NULL;
+  temp = temp->next;
+  for (std::string::const_iterator it = line.begin(); it != line.end(); ++it)
+  {
+    if ((isblank(*it) && *(it + 1) != '/') || *it == '{')
     {
-        if ((isblank(*it) && *(it + 1) != '/') || *it == '{')
-            continue;
-        temp->categoly += *it;
+      continue;
     }
-    return temp;
+    temp->category += *it;
+  }
+  return (temp);
 }
 
 CommonParser::~CommonParser()
 {
-    ParserNode *origin;
-    ParserNode *temp;
+  ParserNode *origin;
+  ParserNode *temp;
 
-    for (unsigned int i = 0; i < nodevector.size(); ++i)
+  for (unsigned int i = 0; i < _nodeVector.size(); ++i)
+  {
+    origin = _nodeVector[i].next;
+    while (origin)
     {
-        origin = nodevector[i].next;
-        while (origin)
-        {
-            temp = origin->next;
-            delete origin;
-            origin = temp;
-        }
+      temp = origin->next;
+      delete (origin);
+      origin = temp;
     }
+  }
 }
 
-void ConfigParser::parsingOneNode(std::istream& is)
+void ConfigParser::parsingOneNode(std::istream &is)
 {
-    std::string buffer;
-    ParserNode rootnode;
-    ParserNode *temp = &rootnode;
+  std::string buffer;
+  ParserNode rootNode;
+  ParserNode *temp = &rootNode;
 
-    rootnode.next = NULL;
-    rootnode.prev = NULL;
-    while (!getline(is, buffer).eof())
+  rootNode.next = NULL;
+  rootNode.prev = NULL;
+  while (!getline(is, buffer).eof())
+  {
+    if (buffer.empty())
     {
-        if (buffer.size() == 0)
-            continue;
-        if (*buffer.rbegin() == ';')
-            getElem(temp, buffer);
-        else if(*buffer.rbegin() == '{')
-            temp = EnterNode(temp, buffer);
-        else if(*buffer.rbegin() == '}')
-        {
-            if (temp == rootnode.next)
-                break;
-            temp = rootnode.next;
-        }
-        buffer.clear();
+      continue;
     }
-    if (rootnode.next)
-        nodevector.push_back(rootnode);
+    if (*buffer.rbegin() == ';')
+    {
+      getElem(temp, buffer);
+    }
+    else if (*buffer.rbegin() == '{')
+    {
+      temp = EnterNode(temp, buffer);
+    }
+    else if (*buffer.rbegin() == '}')
+    {
+      if (temp == rootNode.next)
+      {
+        break;
+      }
+      temp = rootNode.next;
+    }
+    buffer.clear();
+  }
+  if (rootNode.next)
+  {
+    _nodeVector.push_back(rootNode);
+  }
 }
 
-void ConfigParser::getAllowMethods(std::vector<MethodType>& _allowMethods, std::string categoly, unsigned int server_index)
+void ConfigParser::getAllowMethods(std::vector<MethodType> &_allowMethods,
+                                   const std::string& category,
+                                   unsigned int server_index)
 {
-    std::vector<std::string> methods;
+  std::vector<std::string> methods;
 
-    methods = GetNodeElem(server_index, categoly, "allow_methods");
-    for (unsigned int i = 0; i < methods.size(); ++i)
-    {
-        switch (getMethodType(methods[i]))
-        {
-        case GET:
-            _allowMethods.push_back(GET);
-            break;
-        case POST:
-            _allowMethods.push_back(POST);
-            break;
-        case PUT:
-            _allowMethods.push_back(PUT);
-            break;
-        case PATCH:
-            _allowMethods.push_back(PATCH);
-            break;
-        case DELETE:
-            _allowMethods.push_back(DELETE);
-            break;
-        default:
-            _allowMethods.push_back(UNDEFINED);
-            break;
-        }
-    }
+  methods = GetNodeElem(server_index, category, "allow_methods");
+  for (unsigned int i = 0; i < methods.size(); ++i)
+  {
+    MethodType method = getMethodType(methods[i]);
+    _allowMethods.push_back(method);
+  }
 }
 
-void ConfigParser::getLocationAttr(Server& server, unsigned int server_index)
+void ConfigParser::getLocationAttr(Server &server, unsigned int server_index)
 {
-    size_t found;
-    std::string temp_cate;
-    std::vector<std::string> temp2;
-    Location location;
+  size_t found;
+  std::string temp_cate;
+  std::vector<std::string> temp2;
+  Location location;
 
-    for (ParserNode* temp = nodevector[server_index].next; temp != NULL; temp = temp->next)
+  for (ParserNode *temp = _nodeVector[server_index].next;
+       temp != NULL; temp = temp->next)
+  {
+    found = temp->category.find("location ");
+    if (found != std::string::npos)
     {
-        found = temp->categoly.find("location ");
-        if (found != std::string::npos)
-        {
-            temp_cate = temp->categoly;
-            temp_cate.erase(temp_cate.begin(), temp_cate.begin() + 9);
-            location._location = temp_cate;
-            location._index = *(GetNodeElem(server_index, temp->categoly, "index").begin());
-            location._root = *(GetNodeElem(server_index, temp->categoly, "root").begin());
-            getAllowMethods(location._allowMethods, temp->categoly, server_index);
-            location.client_max_body_size = 10000;
-            location._cgiInfo = GetNodeElem(server_index, temp->categoly, "cgi_info");
-            server._locations.push_back(location);
-            location._allowMethods.clear();
-            location._cgiInfo.clear();           
-        }
+      temp_cate = temp->category;
+      temp_cate.erase(temp_cate.begin(), temp_cate.begin() + 9);
+      location.location = temp_cate;
+      location.index = *(GetNodeElem(server_index,
+                                     temp->category,
+                                     "index").begin());
+      location.root = *(GetNodeElem(server_index,
+                                    temp->category,
+                                    "root").begin());
+      getAllowMethods(location.allowMethods, temp->category, server_index);
+      location.ClientMaxBodySize = 10000; // FIXME
+      location.cgiInfo = GetNodeElem(server_index, temp->category, "cgi_info");
+      server._locations.push_back(location);
+      location.allowMethods.clear();
+      location.cgiInfo.clear();
     }
+  }
 }
 
-void ConfigParser::displayServer(Server& server)
+void ConfigParser::displayServer(Server &server)
 {
-    std::cout << "server _allowMethods : ";
-    for (unsigned int i = 0; i < server._allowMethods.size(); ++i)
-        std::cout << server._allowMethods[i] << " ";
+  std::cout << "server allowMethods : ";
+  for (unsigned int i = 0; i < server._allowMethods.size(); ++i)
+  {
+    std::cout << server._allowMethods[i] << " ";
+  }
+  std::cout << std::endl;
+  std::cout << "error_page : " << std::endl;
+  for (std::map<StatusCode, std::string>::iterator it = server._errorPage.begin();
+       it != server._errorPage.end(); ++it)
+  {
+    std::cout << it->first << " : ";
+    std::cout << it->second << std::endl;
+  }
+  std::cout << std::endl;
+  for (unsigned int i = 0; i < server._locations.size(); ++i)
+  {
+    std::cout << "location : " << server._locations[i].location << std::endl;
+    std::cout << "index : " << server._locations[i].index << std::endl;
+    std::cout << "root : " << server._locations[i].root << std::endl;
+    std::cout << "maxsize : " << server._locations[i].ClientMaxBodySize
+              << std::endl;
+    std::cout << "location allow methods: ";
+    for (unsigned int k = 0; k < server._locations[i].allowMethods.size(); ++k)
+    {
+      std::cout << server._locations[i].allowMethods[k] << " ";
+    }
     std::cout << std::endl;
-    std::cout << "error_page : " << std::endl;
-        for (std::map<StatusCode, std::string>::iterator it = server._errorPage.begin(); it != server._errorPage.end(); ++it)
-        {
-            std::cout << it->first << " : ";
-            std::cout << it->second << std::endl;
-        }
+    std::cout << "cgiInfo : ";
+    for (unsigned int k = 0; k < server._locations[i].cgiInfo.size(); ++k)
+    {
+      std::cout << server._locations[i].cgiInfo[k] << " ";
+    }
     std::cout << std::endl;
-    for (unsigned int i = 0; i < server._locations.size(); ++i)
-    {
-        std::cout << "_location : " << server._locations[i]._location << std::endl;
-        std::cout << "_index : " << server._locations[i]._index << std::endl;
-        std::cout << "_root : " << server._locations[i]._root << std::endl;
-        std::cout << "maxsize : " << server._locations[i].client_max_body_size << std::endl;
-        std::cout << "location allow methods: ";
-        for (unsigned int k = 0; k < server._locations[i]._allowMethods.size(); ++k)
-            std::cout << server._locations[i]._allowMethods[k] << " ";
-        std::cout << std::endl;
-        std::cout << "_cgiInfo : ";
-        for (unsigned int k = 0; k < server._locations[i]._cgiInfo.size(); ++k)
-            std::cout << server._locations[i]._cgiInfo[k] << " ";
-        std::cout << std::endl;
-    }
+  }
 }
 
-void ConfigParser::getErrorPage(std::map<StatusCode, std::string>& _errorPage, unsigned int server_index)
+void ConfigParser::getErrorPage(std::map<StatusCode, std::string> &_errorPage,
+                                unsigned int server_index)
 {
-    ParserNode* error_page_node = getNode(server_index, "error_page");
-    std::map<std::string, std::vector<std::string> >::iterator it;
+  ParserNode *errorPageNode = getNode(server_index, "error_page");
+  std::map<std::string, std::vector<std::string> >::iterator it;
 
-    if (error_page_node)
+  if (errorPageNode)
+  {
+    for (it = errorPageNode->elem.begin();
+         it != errorPageNode->elem.end(); ++it)
     {
-        for (it = error_page_node->elem.begin(); it != error_page_node->elem.end(); ++it)
-            _errorPage[std::stod(it->first)] = *(it->second.begin());
+      _errorPage[std::stod(it->first)] = *(it->second.begin());
     }
+  }
 }
+
 //begin empty일때
-void ConfigParser::getServerAttr(Server& server, unsigned int server_index)
+void ConfigParser::getServerAttr(Server &server, unsigned int server_index)
 {
-    std::string hostLine;
+  std::string hostLine;
 
-    hostLine = *(GetNodeElem(server_index, "server", "listen").begin());
-    hostLine.erase(hostLine.begin(), hostLine.begin() + hostLine.find(':') + 1);//find exception
-    inet_pton(AF_INET, "0.0.0.0", &server._socketAddr.sin_addr);
-    server._socketAddr.sin_port = ntohs(static_cast<uint16_t>(std::stod(hostLine)));
-    server._socketAddr.sin_family = AF_INET;
-    server._index = *(GetNodeElem(server_index, "server", "index").begin());
-    server._root = *(GetNodeElem(server_index, "server", "root").begin());
-    getAllowMethods(server._allowMethods, "server", server_index);
-    getLocationAttr(server, server_index);
-    getErrorPage(server._errorPage, server_index);
-    displayServer(server);
+  hostLine = *(GetNodeElem(server_index, "server", "listen").begin());
+  hostLine.erase(hostLine.begin(),
+                 hostLine.begin() + hostLine.find(':') + 1);//find exception
+  // FIXME : hot address, port 반영해야함
+  inet_pton(AF_INET, "0.0.0.0", &server._socketAddr.sin_addr);
+  server._socketAddr.sin_port = ntohs(static_cast<uint16_t>(std::stod(hostLine)));
+  server._socketAddr.sin_family = AF_INET;
+  server._index = *(GetNodeElem(server_index, "server", "index").begin());
+  server._root = *(GetNodeElem(server_index, "server", "root").begin());
+  getAllowMethods(server._allowMethods, "server", server_index);
+  getLocationAttr(server, server_index);
+  getErrorPage(server._errorPage, server_index);
+  displayServer(server);
 }
 
-std::vector<Server> ConfigParser::parsing(std::string FileRoot)
+std::vector<Server> ConfigParser::parsing(const std::string& FileRoot)
 {
-    std::filebuf fb;
-    std::vector<Server> _serverList;
+  std::filebuf fb;
+  std::vector<Server> _serverList;
 
-    if (fb.open(FileRoot, std::ios::in) == NULL)
-        throw (std::runtime_error("open fail\n"));
-    std::istream is(&fb);
-    while (is)
-        parsingOneNode(is);
-    fb.close();
-    _serverList.resize(nodevector.size());
-    for (unsigned int i = 0; i < nodevector.size(); ++i)
-        getServerAttr(_serverList[i], i);
-    return (_serverList);
+  if (fb.open(FileRoot, std::ios::in) == NULL)
+  {
+    throw (std::runtime_error("open fail\n"));
+  }
+  std::istream is(&fb);
+  while (is)
+  {
+    parsingOneNode(is);
+  }
+  fb.close();
+  _serverList.resize(_nodeVector.size());
+  const unsigned int SIZE = _nodeVector.size();
+  for (unsigned int i = 0; i < SIZE; ++i)
+  {
+    getServerAttr(_serverList[i], i);
+  }
+  return (_serverList);
 }

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -4,7 +4,7 @@ ServerManager::ServerManager(const std::string &configFilePath)
 {
   ConfigParser parser;
   _serverList = parser.parsing(configFilePath);
-  parser.displayAll();
+  //parser.displayAll();
 }
 
 ServerManager::~ServerManager()


### PR DESCRIPTION
*configparser version 1.00*

필요한 값이 없을 경우 사이즈 1짜리 벡터를 넣어놔서 begin()값을 참조해도 터지지는 않는데 찾으려는 key:value 가 없는 경우 vector.begin()의 string값이 empty인지 확인해야함

**또한 인자에 따라 nginx가 정의해 놓은 default값이 있을텐데 그것을 어떻게 해야 할지 추후 논의가** 필요함 지금은 그냥 빈 string을 넣어놓았음