### PR TITLE
feat: POST PUT 요청 처리

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -36,6 +36,10 @@ server {
 		allow_methods : GET POST;
 		redirect : 304 https://www.naver.com/;
 	}
+	location /repository {
+	    allow_methods : POST PUT DELETE;
+	    root: ../www;
+	}
 
 	redirect : 301 https://profile.intra.42.fr/;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -131,6 +131,7 @@ HTTPResponse* Server::processGETRequest(const struct Context* context)
 // TODO: 현재는 POST 요청시 생성할 파일명까지 명시하지만,
 // TODO: 사실 요청은 경로만 입력되있고 이걸 서버가 알아서 판단, 파일을 생성한뒤 그 파일에 대한 identifier를 response해야 함.
 // TODO: 이 부분은 form-data 처리랑도 연관 있으니 추후 토의후 마저 구현할 것.
+// 참고 내용 : http://blog.storyg.co/rest-api-response-body-best-pratics
 HTTPResponse* Server::processPOSTRequest(struct Context* context)
 {
   HTTPRequest& req = *context->req;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -128,6 +128,9 @@ HTTPResponse* Server::processGETRequest(const struct Context* context)
 
 // Process POST reqeust
 // Test on bash : curl -X POST http://127.0.0.1:4242/repository/test -d "Hello, World"
+// TODO: 현재는 POST 요청시 생성할 파일명까지 명시하지만,
+// TODO: 사실 요청은 경로만 입력되있고 이걸 서버가 알아서 판단, 파일을 생성한뒤 그 파일에 대한 identifier를 response해야 함.
+// TODO: 이 부분은 form-data 처리랑도 연관 있으니 추후 토의후 마저 구현할 것.
 HTTPResponse* Server::processPOSTRequest(struct Context* context)
 {
   HTTPRequest& req = *context->req;
@@ -151,7 +154,7 @@ HTTPResponse* Server::processPOSTRequest(struct Context* context)
     }
     else // if file exist
     {
-      response = new HTTPResponse(ST_NO_CONTENT, std::string("OK"), context->manager->getServerName(context->addr.sin_port));
+      response = new HTTPResponse(ST_OK, std::string("OK"), context->manager->getServerName(context->addr.sin_port));
     }
     response->setFd(-1);
     // attach write event
@@ -200,6 +203,7 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     {
       response = new HTTPResponse(ST_NO_CONTENT, std::string("OK"), context->manager->getServerName(context->addr.sin_port));
     }
+    response->addHeader("Content-Location", filePath);
     response->setFd(-1);
     // attach write event
     FileDescriptor writeFileFD = open(filePath.c_str(), O_CREAT | O_TRUNC | O_WRONLY | O_NONBLOCK);

--- a/src/ServerUtil.cpp
+++ b/src/ServerUtil.cpp
@@ -131,23 +131,18 @@ void writeFileHandle(struct Context* context)
   HTTPRequest& req = *context->req;
 
   ssize_t writeSize = 0;
-  // 덜 써졌을 때 마저 보내기 위함.
-  std::string bodySubstr = req.body.substr(context->buffer_size, std::string::npos);
+  std::string bodySubstr = req.body.substr(context->buffer_size, req.body.size());
   if ((writeSize = write(context->fd,bodySubstr.c_str(), req.body.size() - context->buffer_size)) < 0)
   {
     printLog("error: client: " + getClientIP(&context->addr) + " : write failed\n", PRINT_RED);
   }
-  if (writeSize < req.body.size()) // If partial read.
-  {
-    context->buffer_size += writeSize;
-    return ;
-  }
-  else if (context->buffer_size >= req.body.size()) // If write finished
+  context->buffer_size += writeSize; // get total write size
+  if (context->buffer_size >= req.body.size()) // If write finished
   {
     close(context->fd);
-    context->fd = -1;
+    delete (context->req);
+    delete (context);
   }
-  delete (context);
 }
 
 //https://stackoverflow.com/questions/154536/encode-decode-urls-in-c

--- a/www/test
+++ b/www/test
@@ -1,0 +1,1 @@
+Hello, World2\n


### PR DESCRIPTION
테스트는 
curl -X POST http://127.0.0.1:4242/repository/test -d "Hello, World"  --> 뒤에 이어 쓰기
curl -X PUT http://127.0.0.1:4242/repository/test -d "Hello, World" --> 내용 갈아엎기
로 진행했습니다.  

현재 코드는 POST PUT 실행시 둘다 파일 없으면 새로 생성하고, 파일이 이미 있으면 append하냐 덮어쓰냐의 차이만 있습니다.
일단 병합 한 후에, POST에서 경로만 들어왔을때 서버가 알아서 판단 후 생성한 파일의 identifier를 반환하도록 수정할 예정입니다.

+)  DELETE는 테스트하지 않았습니다.