### PR TITLE
Tester 돌리기 위한 수정 작업 완료.

### DIFF
--- a/YoupiBanane/Yeah/not_happy.bad_extension
+++ b/YoupiBanane/Yeah/not_happy.bad_extension
@@ -1,0 +1,1 @@
+Yeah/not_happy.bad_extension

--- a/YoupiBanane/nop/other.pouic
+++ b/YoupiBanane/nop/other.pouic
@@ -1,0 +1,1 @@
+nop/other.pouic

--- a/YoupiBanane/nop/youpi.bad_extension
+++ b/YoupiBanane/nop/youpi.bad_extension
@@ -1,0 +1,1 @@
+nop/youpi.bad_extension

--- a/YoupiBanane/youpi.bad_extension
+++ b/YoupiBanane/youpi.bad_extension
@@ -1,0 +1,1 @@
+youpi.bad_extension

--- a/YoupiBanane/youpi.bla
+++ b/YoupiBanane/youpi.bla
@@ -1,0 +1,1 @@
+youpi.bla

--- a/config/default.conf
+++ b/config/default.conf
@@ -1,27 +1,42 @@
 server {
 	server_name : 127.0.0.1;
 	listen : 127.0.0.1:4242;
-
 	root : ../;
-
-	allow_methods : GET POST DELETE;
-
+	allow_methods : GET;
 	index : index.html;
 	client_max_body_size : 10000;
 
 	error_page {
-		404 : ./www/html/error/error.html;
-		405 : ./www/html/error/error.html;
-		505 : ./www/html/error/error2.html;
-		500 : ./www/html/error/error2.html;
+		404 : ../www/html/error/error.html;
+		405 : ../www/html/error/error.html;
+		505 : ../www/html/error/error2.html;
+		500 : ../www/html/error/error2.html;
 	}
+
+
+	location /put_test {
+			allow_methods : PUT;
+			root : ../www;
+	}
+	location /post_body {
+			allow_methods : POST;
+			root : ../www;
+			client_max_body_size : 100;
+	}
+	location /directory {
+			allow_methods : GET;
+			index : youpi.bad_extension;
+			root : ../YoupiBanane;
+	}
+
+
 	location /board {
 			allow_methods : GET;
-			root : ./www/html;
+			root : ../www/html;
 	}
 	location /board/content {
 			allow_methods : GET POST DELETE;
-			root : ./www/html/contents;
+			root : ../www/html/contents;
 			index : board.html;
 			cgi_info : .php php-cgi;
             client_max_body_size : 100;
@@ -31,15 +46,11 @@ server {
 		cgi_info : php php-fpm;
 	}
 	location /redirection_test {
-	    index : test.html;
-		root : ./www/redirection;
-		allow_methods : GET POST;
+		allow_methods : GET POST PUT DELETE;
 		redirect : 304 https://www.naver.com/;
 	}
 	location /repository {
 	    allow_methods : POST PUT DELETE;
 	    root: ../www;
 	}
-
-	redirect : 301 https://profile.intra.42.fr/;
 }

--- a/config/default.conf
+++ b/config/default.conf
@@ -16,11 +16,11 @@ server {
 
 	location /put_test {
 			allow_methods : PUT;
-			root : ../www;
+			root : ../YoupiBanane;
 	}
 	location /post_body {
 			allow_methods : POST;
-			root : ../www;
+			root : ../YoupiBanane;
 			client_max_body_size : 100;
 	}
 	location /directory {

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -34,6 +34,7 @@ public:
     std::pair<StatusCode, std::string> _redirect;
     Location* getMatchedLocation(const HTTPRequest& req);
     void processRequest(struct Context* context);
+    FileDescriptor getErrorPageFd(const StatusCode& stCode); // open and return ErrorPage file_descriptor.
     void openServer();
 
     // check if server has valid redirection setting. (1. 서버 자체가 리다이렉션인지도 체크)

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -295,21 +295,25 @@ FileDescriptor HTTPResponse::getFd() const
 
 void HTTPResponse::sendToClient(struct Context* context)
 {
-  clearContexts(context);
+  clearContexts(context); // FIX: 여기서 터진다!
   if (this->getHeader().getStatusCode() >= 400)
     this->addHeader("Connection", "close");
+
   // (1) Send Header
   struct Context* newSendContext = new struct Context(context->fd, context->addr, socketSendHandler, context->manager);
   newSendContext->connectContexts = context->connectContexts;
   newSendContext->connectContexts->push_back(newSendContext);
-  newSendContext->res = this;
+  newSendContext->res = new HTTPResponse(*this);
+
   // add header content
   std::string header = this->getHeader().toString() + "\n";
   newSendContext->ioBuffer = new char[header.size()];
   memmove(newSendContext->ioBuffer, header.c_str(), header.size());
   newSendContext->bufferSize = header.size();
   newSendContext->threadKQ = context->threadKQ;
-  newSendContext->req = context->req;
+//  newSendContext->req = context->req;
+  newSendContext->req = new HTTPRequest(*context->req);
+
   struct kevent event;
   EV_SET(&event, newSendContext->fd, EVFILT_WRITE, EV_ADD | EV_CLEAR, 0, 0, newSendContext);
   context->manager->attachNewEvent(newSendContext, event);
@@ -324,16 +328,14 @@ void HTTPResponse::sendToClient(struct Context* context)
     struct Context* newReadContext = new struct Context(context->fd, context->addr, bodyFdReadHandler, context->manager);
     newReadContext->connectContexts = context->connectContexts;
     newReadContext->connectContexts->push_back(newReadContext);
-    newReadContext->res = this;
-    newReadContext->req = context->req;
+    newReadContext->res = new HTTPResponse(*this);
+    newReadContext->req = new HTTPRequest(*context->req);
     newReadContext->threadKQ = context->threadKQ;
     struct kevent _event;
     EV_SET(&_event, newReadContext->res->_fileFd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, newReadContext);
     context->manager->attachNewEvent(newReadContext, _event);
   }
   printLog(methodToString(context->req->method)  + "\t\t" + getClientIP(&context->addr) + '\t' + ft_itos(context->res->_status_code) + '\n', ((int)context->res->_status_code < 400) ? PRINT_BLUE : PRINT_MAGENTA);
-  // 다음 요청에서 재사용하지 않기 위해서 처리함.
-//  delete (context->req);
   context->req = NULL;
 }
 
@@ -368,7 +370,7 @@ void HTTPResponse::socketSendHandler(struct Context* context)
     if (context->res->_fileFd > 0 && context->res->getContentLength() > context->totalIOSize)
     {
       struct Context* newReadContext = new struct Context(context->fd, context->addr, bodyFdReadHandler, context->manager);
-      newReadContext->res = context->res;
+      newReadContext->res = new HTTPResponse(*context->res);
       newReadContext->threadKQ = context->threadKQ;
       newReadContext->totalIOSize = context->totalIOSize;
       newReadContext->connectContexts = context->connectContexts;
@@ -414,6 +416,7 @@ void HTTPResponse::bodyFdReadHandler(struct Context* context)
     }
     close(context->res->_fileFd);
     delete[] (buffer);
+    buffer = NULL;
   }
   else // 데이터가 들어왔다면, 소켓에 버퍼에 있는 데이터를 전송하는 socket send event를 등록.
   {
@@ -431,7 +434,8 @@ void HTTPResponse::bodyFdReadHandler(struct Context* context)
     struct Context* newSendContext = new struct Context(context->fd, context->addr, socketSendHandler, context->manager);
     newSendContext->connectContexts = context->connectContexts;
     newSendContext->connectContexts->push_back(newSendContext);
-    newSendContext->res = context->res;
+//    newSendContext->res = context->res;
+    newSendContext->res = new HTTPResponse(*context->res);
     newSendContext->ioBuffer = buffer;
     newSendContext->threadKQ = context->threadKQ;
     newSendContext->bufferSize = current_rd_size;

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -25,26 +25,14 @@ bool Location::isMatchedLocation(const std::string& url) const
 // check url is in location first...
 std::string Location::convertURLToLocationPath(const std::string& url) const
 {
-  if (!isMatchedLocation(url))
-  {
-    throw (std::runtime_error("invalid url in this location : " + _location + "\n"));
-  }
   std::string result = _root;
-  std::string filePath = url.substr(url.rfind('/'));
-  if (_location != filePath)
-  {
-    if (filePath[filePath.size()] == '/') // if [ /foo/bar/ ]
-      result = _root + filePath.substr(0, filePath.size() - 1);
-    else // if [ /foo/bar ]
-      result = _root + filePath;
-  }
+  std::string filePath;
+  filePath = url.substr(this->_location.size(), std::string::npos);
+  result = _root + filePath;
   struct stat sb;
-  if (stat(result.c_str(), &sb) == -1) // neither a file nor directory.
-    return ("FAILED");
-  if (S_ISDIR(sb.st_mode))
-  {
+  // if last url-chunk is directory, add location's _index to url. [ Ex. /YoupiBane => /YoupiBane/index.html ]
+  if (stat(result.c_str(), &sb) != -1 && S_ISDIR(sb.st_mode))
     result += ("/" + _index);
-  }
   return (result);
 }
 

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -40,6 +40,28 @@ void RequestParser::checkBodyLength(HTTPRequest* request)
   }
 }
 
+// 16진수 문자열을 long으로 변환
+long convertHexStrToLong(const std::string& hex)
+{
+  long result = 0;
+
+  static const std::string HEX_LOOKUP("0123456789abcdef");
+  for (std::string::const_iterator itr = hex.begin(); itr != hex.end(); itr++)
+  {
+    int i = 0;
+    while (i < 16)
+    {
+      if (HEX_LOOKUP[i] == *itr)
+      {
+        result = (result + i) * 16;
+        break;
+      }
+      i++;
+    }
+  }
+  return (result / 16);
+}
+
 void RequestParser::parseChunked(HTTPRequest* request)
 {
   std::string endcheck;
@@ -73,8 +95,10 @@ void RequestParser::parseChunked(HTTPRequest* request)
   {
     it = getOneLine(length_str, it, end);
     it = getOneLine(val, it, end);
-    length_int = strtol(length_str.c_str(), &endptr, 10);
-    if (*endptr != '\0' || length_int < 0)
+
+    // FIXME : chunked의 length 정보가 hex(16진수)로 들어온다 --> ex. 3e8
+    length_int = convertHexStrToLong(length_str);
+    if (length_int < 0)
     {
       throw std::logic_error("chunked length value error");
     }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -357,7 +357,10 @@ void RequestParser::parseRequest(struct Context* context)
     }
   }
   if (context->req->status == ERROR || context->req->status == END)
+  {
     delete (context->req->message);
+    context->req->message = NULL;
+  }
   context->manager->getRequestProcessor().processRequest(context);
 }
 

--- a/src/RequestProcessor.cpp
+++ b/src/RequestProcessor.cpp
@@ -132,7 +132,10 @@ void RequestProcessor::processRequest(struct Context* context)
       response->addHeader(HTTPResponseHeader::CONTENT_LENGTH(0));
       response->sendToClient(context);
       if (req.status == HEADEROK)
+      {
         delete (req.message);
+        req.message = NULL;
+      }
       return;
     }
     // * if redirection.

--- a/src/RequestProcessor.cpp
+++ b/src/RequestProcessor.cpp
@@ -23,10 +23,9 @@ static bool isAllowedMethod(std::vector<MethodType>& allowMethods, MethodType me
 // ASSUMPTION : request contain complete header...
 
 // WARN: Test code!
-StatusCode checkValidUrl_recur(const Server& matchedServer, const std::string& url)
+StatusCode checkValidUrl_recur(const Server& matchedServer, const std::string& subUrl)
 {
-  const std::string substr = url.substr(0, url.rfind('/'));
-  if (substr == url) // if substr has no /
+  if (subUrl.empty()) // if substr has no /
   {
     return (ST_NOT_FOUND);
   }
@@ -36,11 +35,11 @@ StatusCode checkValidUrl_recur(const Server& matchedServer, const std::string& u
           ++it
           ) {
     const Location &loc = *it;
-    if (loc.isMatchedLocation(url)) {
+    if (loc._location == subUrl) {
       return (ST_OK); // 경로를 뒤에서 하나씩 제거해보면서 location과 지속 비교.
     }
   }
-  return (checkValidUrl_recur(matchedServer, substr));
+  return (checkValidUrl_recur(matchedServer, subUrl.substr(0, subUrl.rfind('/'))));
 }
 
 
@@ -57,7 +56,8 @@ StatusCode RequestProcessor::checkValidHeader(const HTTPRequest& req)
     // http://127.0.0.1:4242/directory/nop/ 와 같은 경우도 고려해야 함.
     if (req.url != "/")
     {
-      return (checkValidUrl_recur(matchedServer, req.url)); // recursive location checking.
+      const StatusCode st = checkValidUrl_recur(matchedServer, req.url);
+      return (st);
     }
     if (!isAllowedMethod(matchedServer._allowMethods, req.method))
     {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -212,7 +212,7 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     HTTPResponse* response = NULL;
 
     // FIXME : 왜 이미 있는 파일의 경우 fd가 쟈꾸 -1이 되지...?
-    FileDescriptor writeFileFD = open(filePath.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_NONBLOCK);
+    FileDescriptor writeFileFD = open(filePath.c_str(), O_CREAT | O_TRUNC | O_NONBLOCK, 0777);
     if (writeFileFD <= -1)
     {
       const StatusCode RETURN_STATUS = ST_BAD_REQUEST;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -116,7 +116,6 @@ HTTPResponse* Server::processGETRequest(const struct Context* context)
     const StatusCode RETURN_STATUS = ST_NOT_FOUND;
     HTTPResponse* response = new HTTPResponse(RETURN_STATUS, std::string("not found"), context->manager->getServerName(context->addr.sin_port));
     response->setFd(getErrorPageFd(RETURN_STATUS));
-//    response->addHeader(HTTPResponse::CONTENT_LENGTH(FdGetFileSize(response->getFd())));
     return (response);
   }
   // check this file is CGI path
@@ -133,14 +132,12 @@ HTTPResponse* Server::processGETRequest(const struct Context* context)
     const StatusCode RETURN_STATUS = ST_NOT_FOUND;
     HTTPResponse* response = new HTTPResponse(RETURN_STATUS, std::string("not found"), context->manager->getServerName(context->addr.sin_port));
     response->setFd(getErrorPageFd(RETURN_STATUS));
-//    response->addHeader(HTTPResponse::CONTENT_LENGTH(FdGetFileSize(response->getFd())));
-//    return (response);
+    return (response);
   }
   else
   {
     HTTPResponse* response = new HTTPResponse(ST_OK, std::string("OK"), context->manager->getServerName(context->addr.sin_port));
     response->setFd(open(filePath.c_str(), O_RDONLY));
-//    response->addHeader(HTTPResponse::CONTENT_LENGTH(FdGetFileSize(response->getFd())));
     return (response);
   }
 }
@@ -345,10 +342,8 @@ void Server::processRequest(struct Context* context)
     }
   }
   context->res = response;
-  if (response->getFd() > 0)
+  if (context->res && response->getFd() > 0)
     response->addHeader(HTTPResponseHeader::CONTENT_LENGTH(FdGetFileSize(response->getFd())));
-  else
-    response->addHeader(HTTPResponseHeader::CONTENT_LENGTH(0));
   response->sendToClient(context); // FIXME : 이런 형태로 고쳐져야함.
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -212,7 +212,7 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     HTTPResponse* response = NULL;
 
     // FIXME : 왜 이미 있는 파일의 경우 fd가 쟈꾸 -1이 되지...?
-    FileDescriptor writeFileFD = open(filePath.c_str(), O_CREAT | O_TRUNC | O_NONBLOCK, 777);
+    FileDescriptor writeFileFD = open(filePath.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_NONBLOCK);
     if (writeFileFD <= -1)
     {
       const StatusCode RETURN_STATUS = ST_BAD_REQUEST;

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -19,6 +19,7 @@ ServerManager::~ServerManager()
           )
   {
     delete (*it);
+    *it = NULL;
   }
 }
 

--- a/src/ServerUtil.cpp
+++ b/src/ServerUtil.cpp
@@ -249,17 +249,30 @@ void clearContexts(struct Context* context)
 
     if (data == context)
       continue;
+
     if (data->req != NULL)
+    {
       delete (data->req);
+      data->req = NULL;
+    }
     if (data->res)
       res = data->res;
     if (data->ioBuffer != NULL)
+    {
       delete (data->ioBuffer);
+      data->ioBuffer = NULL;
+    }
     if (data != context)
+    {
       free (data);
+      data = NULL;
+    }
   }
   if (res != NULL)
+  {
     delete (res);
+    res = NULL;
+  }
   context->connectContexts->clear();
   context->connectContexts->push_back(context);
 }

--- a/src/ServerUtil.cpp
+++ b/src/ServerUtil.cpp
@@ -229,6 +229,8 @@ int ft_stoi(const std::string& str)
 
 long FdGetFileSize(int fd)
 {
+  if (fd < 0)
+    return 0;
   struct stat stat_buf;
   int rc = fstat(fd, &stat_buf);
   return rc == 0 ? stat_buf.st_size : -1;

--- a/www/html/content/board.html
+++ b/www/html/content/board.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+board.html
+</body>
+</html>

--- a/www/html/error/error.html
+++ b/www/html/error/error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>40x</title>
+</head>
+<body>
+    <h1>40x</h1>
+    <h2>Woops! Something went wrong!</h2>
+</body>
+</html>

--- a/www/html/error/error2.html
+++ b/www/html/error/error2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>50x</title>
+</head>
+<body>
+    <h1>50x</h1>
+    <h2>Woops! looks like our server is down!</h2>
+</body>
+</html>


### PR DESCRIPTION
- tester에 맞춰 환경설정 완료했습니다. 
- Location matching 방식이 바뀌었습니다. Server Config에 url 경로 전체가 명시되어 있지 않아도, 가장 근접한 Location을 찾아 반환합니다. 
--> tester 실행시 
.`/directory/subdirectory` url에대한 index 처리와, `./directory/file` url에 대한 에러코드 반환 처리하기 위함



[FIXME]
1. 테스트 케이스 후반부에 (?) PUT 쪽에서 segfault 납니다. PUT 할때 clearContext() 부분에서 터지는건데, 이 부분은 어떻게 고쳐야 할지 모르겠습니다 ㅠ (여기서 테스터가 종료되기에 이후 남은 테스트케이스가 뭔지 확인이 안됨).
2. processPUT 에서 할 때 이미 존재하는 file은 open이 안됩니다. 이 부분 고쳐야 합니다. (FIXME로 주석 표기해둠)
- 한국 16강 진출했다 와!
