### PR TITLE
write handler fix

### DIFF
--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -347,7 +347,10 @@ void HTTPResponse::socketSendHandler(struct Context* context)
   }
   // 이 콜백은 socekt send 가능한 시점에서 호출되기 때문에, 이대로만 사용하면 된다.
   ssize_t sendSize;
-
+  std::string temp;
+  temp.assign(context->ioBuffer, context->bufferSize);
+  std::cerr << "send message" << std::endl;
+  std::cerr << temp << std::endl;
   if ((sendSize = send(context->fd, context->ioBuffer, context->bufferSize, MSG_DONTWAIT)) < 0)
   {
     if (DEBUG_MODE)

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -347,10 +347,11 @@ void HTTPResponse::socketSendHandler(struct Context* context)
   }
   // 이 콜백은 socekt send 가능한 시점에서 호출되기 때문에, 이대로만 사용하면 된다.
   ssize_t sendSize;
+  /* send message 확인
   std::string temp;
   temp.assign(context->ioBuffer, context->bufferSize);
   std::cerr << "send message" << std::endl;
-  std::cerr << temp << std::endl;
+  std::cerr << temp << std::endl;*/
   if ((sendSize = send(context->fd, context->ioBuffer, context->bufferSize, MSG_DONTWAIT)) < 0)
   {
     if (DEBUG_MODE)

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -187,7 +187,7 @@ void RequestParser::checkStartLineValid(HTTPRequest* request)
   {
     return;
   }
-  std::cerr << "chekc" << std::endl;
+  std::cerr << "request message" << std::endl;
   std::cerr<< *request->message << std::endl;
   if (request->method == UNDEFINED || \
             !request->url.size() || !request->version.size())
@@ -336,9 +336,10 @@ void RequestParser::readRequest(FileDescriptor fd, HTTPRequest* request)
   {
     throw (std::runtime_error("receive failed\n"));
   }
-std::string temp;
+  //request message print
+/*std::string temp;
 temp.assign(buffer);
-std::cerr << temp << std::endl;
+std::cerr << temp << std::endl;*/
   if (!request->body.size())
   {
     (*request->message) += buffer;

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -187,8 +187,9 @@ void RequestParser::checkStartLineValid(HTTPRequest* request)
   {
     return;
   }
+  /* request message 확인
   std::cerr << "request message" << std::endl;
-  std::cerr<< *request->message << std::endl;
+  std::cerr<< *request->message << std::endl;*/
   if (request->method == UNDEFINED || \
             !request->url.size() || !request->version.size())
   {

--- a/src/RequestProcessor.cpp
+++ b/src/RequestProcessor.cpp
@@ -150,7 +150,7 @@ void RequestProcessor::processRequest(struct Context* context)
 
     if (status != ST_OK)
     {
-      HTTPResponse* response = new HTTPResponse(status, "", context->manager->getServerName(context->addr.sin_port));
+      HTTPResponse* response = new HTTPResponse(status, "No", context->manager->getServerName(context->addr.sin_port));
       context->res = response;
 
       response->addHeader(HTTPResponseHeader::CONTENT_LENGTH(0));

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -181,7 +181,6 @@ HTTPResponse* Server::processPOSTRequest(struct Context* context)
     struct Context* newContext = new struct Context(writeFileFD, context->addr, writeFileHandle, context->manager);
     newContext->res = new HTTPResponse(*response);
     newContext->req = new HTTPRequest(*context->req);
-    //newContext->fd = writeFileFD;
     newContext->threadKQ = context->threadKQ;
     newContext->totalIOSize = 0;
     // attach event
@@ -227,10 +226,7 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     struct Context* newContext = new struct Context(writeFileFD, context->addr, writeFileHandle, context->manager);
     newContext->res = new HTTPResponse(*response);
     newContext->req = new HTTPRequest(*context->req);
-    newContext->fd = writeFileFD;
     newContext->threadKQ = context->threadKQ;
-    //newContext->connectContexts = context->connectContexts;
-    //newContext->connectContexts->push_back(newContext);
     newContext->totalIOSize = 0;
     // attach event
     struct kevent event;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -181,7 +181,7 @@ HTTPResponse* Server::processPOSTRequest(struct Context* context)
     struct Context* newContext = new struct Context(writeFileFD, context->addr, writeFileHandle, context->manager);
     newContext->res = new HTTPResponse(*response);
     newContext->req = new HTTPRequest(*context->req);
-    newContext->fd = writeFileFD;
+    //newContext->fd = writeFileFD;
     newContext->threadKQ = context->threadKQ;
     newContext->totalIOSize = 0;
     // attach event
@@ -212,7 +212,7 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     HTTPResponse* response = NULL;
 
     // FIXME : 왜 이미 있는 파일의 경우 fd가 쟈꾸 -1이 되지...?
-    FileDescriptor writeFileFD = open(filePath.c_str(), O_CREAT | O_TRUNC | O_NONBLOCK, 0777);
+    FileDescriptor writeFileFD = open(filePath.c_str(), O_WRONLY |O_CREAT | O_TRUNC | O_NONBLOCK, 0777);
     if (writeFileFD <= -1)
     {
       const StatusCode RETURN_STATUS = ST_BAD_REQUEST;
@@ -229,8 +229,8 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     newContext->req = new HTTPRequest(*context->req);
     newContext->fd = writeFileFD;
     newContext->threadKQ = context->threadKQ;
-    newContext->connectContexts = context->connectContexts;
-    newContext->connectContexts->push_back(newContext);
+    //newContext->connectContexts = context->connectContexts;
+    //newContext->connectContexts->push_back(newContext);
     newContext->totalIOSize = 0;
     // attach event
     struct kevent event;

--- a/src/ServerUtil.cpp
+++ b/src/ServerUtil.cpp
@@ -142,6 +142,9 @@ void writeFileHandle(struct Context* context)
   ssize_t writeSize = 0;
   if ((writeSize = write(context->fd, &req.body.c_str()[context->totalIOSize], req.body.size() - context->totalIOSize)) < 0)
   {
+    std::cerr << "error check" << std::endl;
+    std::cerr << errno << std::endl;
+    std::cerr << strerror(errno)<< std::endl;
     printLog("error\t\t" + getClientIP(&context->addr) + "\t: write failed\n", PRINT_RED);
   }
   context->totalIOSize += writeSize; // get total write size
@@ -151,6 +154,10 @@ void writeFileHandle(struct Context* context)
     if (context->req != NULL)
     {
       delete (context->req);
+    }
+    if (context->res != NULL)
+    {
+      delete (context->res);
     }
     delete (context);
   }

--- a/src/ServerUtil.cpp
+++ b/src/ServerUtil.cpp
@@ -142,9 +142,6 @@ void writeFileHandle(struct Context* context)
   ssize_t writeSize = 0;
   if ((writeSize = write(context->fd, &req.body.c_str()[context->totalIOSize], req.body.size() - context->totalIOSize)) < 0)
   {
-    std::cerr << "error check" << std::endl;
-    std::cerr << errno << std::endl;
-    std::cerr << strerror(errno)<< std::endl;
     printLog("error\t\t" + getClientIP(&context->addr) + "\t: write failed\n", PRINT_RED);
   }
   context->totalIOSize += writeSize; // get total write size


### PR DESCRIPTION
writeFD를 가진 newContext가 socket을 기준으로 하는 context vector에 추가되어 clearcontext()로 인해 delete되어 heap use after free문제가 발생하는것 수정