### PR TITLE
fix : 비정상 종료시 file descriptor 가 닫히지 않아 발생한 문제 해결

### DIFF
--- a/include/HTTPResponse.hpp
+++ b/include/HTTPResponse.hpp
@@ -155,6 +155,8 @@ public: // * constructor & destuctor
     HTTPResponse(const int& statusCode, const std::string& statusMessage,
                  const std::string& serverName);
     ~HTTPResponse();
+    FileDescriptor _readFD;
+    FileDescriptor _writeFD;
 
 public: // * setter functions
     void setFd(const FileDescriptor& fd);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -280,6 +280,7 @@ HTTPResponse* Server::processPOSTRequest(struct Context* context)
     newContext->totalIOSize = 0;
     newContext->pipeFD[0] = context->pipeFD[0];
     newContext->pipeFD[1] = context->pipeFD[1];
+    response->_writeFD = writeFileFD;
     // attach event
     struct kevent event;
     EV_SET(&event, writeFileFD, EVFILT_WRITE, EV_ADD | EV_CLEAR, 0, 0, newContext);
@@ -328,6 +329,7 @@ HTTPResponse* Server::processPUTRequest(struct Context* context)
     newContext->connectContexts->push_back(newContext);
     newContext->pipeFD[0] = context->pipeFD[0];
     newContext->pipeFD[1] = context->pipeFD[1];
+    response->_writeFD = writeFileFD;
     // attach event
     struct kevent event;
     EV_SET(&event, writeFileFD, EVFILT_WRITE, EV_ADD | EV_CLEAR, 0, 0, newContext);

--- a/src/ServerUtil.cpp
+++ b/src/ServerUtil.cpp
@@ -241,7 +241,7 @@ void writeFileHandle(struct Context* context)
   {
     delete (req.body);
     req.body = NULL;
-    close(context->fd);
+//    close(context->fd);
   }
 }
 


### PR DESCRIPTION
cgi 요청이 아닌 경우 비정상 종료시 일부 FD가 닫히지 않아 발생하는 오류가 있었습니다.
Response 객체에서 해당되는 것들을 모두 담고 Response 객체가 사라질 때 함께 사라지도록 처리했습니다.